### PR TITLE
Silencing the tests that are passing

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,18 +1,79 @@
-// Propagate the logs, but only show warnings and errors
-// Problems of this propagation approach: Node.js prints log buffer in bulk, so console logs and the associated tests that fail don't get placed together to one another.
-// Let's try to keep it like that for now and see the results, but let's keep in mind that this still has room for improvement.
-// Override console to only show warnings and errors
-console.info('Jest custom setup installed.');
+let logBuffer = [];
 
-const originalConsole = global.console;
-global.console = {
-  ...originalConsole,
-  log: () => {}, // Suppress console.log
-  info: () => {}, // Suppress console.info
-  debug: () => {}, // Suppress console.debug
-  // Keep warn and error
-  warn: originalConsole.warn,
-  error: originalConsole.error,
+const methods = ['log', 'info', 'warn', 'error'];
+
+const formatArg = (arg) => {
+  if (typeof arg === 'string') return arg;
+  if (typeof arg === 'number' || typeof arg === 'boolean' || arg === null) return String(arg);
+  try {
+    return JSON.stringify(arg, null, 2);
+  } catch {
+    return '[Unserializable Object]';
+  }
+};
+
+const originalConsole = {};
+
+// Override console methods to buffer logs
+methods.forEach((method) => {
+  originalConsole[method] = console[method];
+  console[method] = (...args) => {
+    logBuffer.push({ method, args });
+  };
+});
+
+// Monkey-patch test to track failure
+const originalTest = global.test;
+
+global.test = (name, fn, timeout) => {
+  originalTest(name, async () => {
+    let failed = false;
+    logBuffer = [];
+
+    try {
+      await fn();
+    } catch (err) {
+      failed = true;
+      throw err;
+    } finally {
+      if (failed && logBuffer.length > 0) {
+        const { testPath, currentTestName } = expect.getState();
+
+        const suite = currentTestName?.replace(name, '').trim() || '(unknown suite)';
+
+        const start_banner = [
+          '─'.repeat(12),
+          `Test "${suite}" > "${name}" failed — console output follows:`,
+          '─'.repeat(12),
+          '',
+        ].join('\n');
+    
+        process.stdout.write(start_banner + '\n');
+  
+        logBuffer.forEach(({ method, args }) => {
+          const prefix = {
+            log: 'console.log ',
+            info: 'console.info',
+            warn: 'console.warn',
+            error: 'console.error',
+          }[method] || 'console.log';
+
+          const msg = args.map(formatArg).join(' ');
+
+          process.stdout.write(`${prefix}: ${msg}\n\n`);
+        });
+
+        const end_banner = [
+          '─'.repeat(12),
+          `End of console output.`,
+          '─'.repeat(12),
+          '',
+        ].join('\n');
+    
+        process.stdout.write(end_banner + '\n');
+      }
+    }
+  }, timeout);
 };
 
 const originalBeforeEach = global.beforeEach;

--- a/run_devrev_snapin_conformance_tests.sh
+++ b/run_devrev_snapin_conformance_tests.sh
@@ -276,7 +276,7 @@ if [ "${VERBOSE:-}" -eq 1 ] 2>/dev/null; then
   printf "Running conformance tests...\n"
 fi
 
-npm test -- --runInBand --silent --setupFilesAfterEnv="$SCRIPT_DIR/jest.setup.js" --detectOpenHandles 2>&1 | sed -E "$ANSI_ESCAPE_PATTERN"
+npm test -- --runInBand --setupFilesAfterEnv="$SCRIPT_DIR/jest.setup.js" --detectOpenHandles 2>&1 | sed -E "$ANSI_ESCAPE_PATTERN"
 conformance_tests_result=$?
 
 if [ $conformance_tests_result -ne 0 ]; then

--- a/run_unittests_jest.sh
+++ b/run_unittests_jest.sh
@@ -75,7 +75,7 @@ rm "$build_output"
 
 printf "### Step 2: Running unittests in $FOLDER_NAME...\n"
 
-npm test -- --runInBand --silent --setupFilesAfterEnv="$SCRIPT_DIR/jest.setup.js" --detectOpenHandles 2>&1 | sed -E "$ANSI_ESCAPE_PATTERN"
+npm test -- --runInBand --setupFilesAfterEnv="$SCRIPT_DIR/jest.setup.js" --detectOpenHandles 2>&1 | sed -E "$ANSI_ESCAPE_PATTERN"
 TEST_EXIT_CODE=$?
 
 # Check if tests failed


### PR DESCRIPTION
When rendering code the logs of successful tests are not bringing any value while they create substantial amount of tokens thus polluting the context. We therefore monkey patch jest setup to silence the tests that are passing.

Work item: https://app.devrev.ai/devrev/works/ISS-188589