### PR TITLE
Removing wrong docs update.

### DIFF
--- a/docs/airdrop_sdk_library_documentation.md
+++ b/docs/airdrop_sdk_library_documentation.md
@@ -390,10 +390,6 @@ Defines the structure of events sent to external extractors from Airdrop platfor
 
   Required. An object containing:
 
-  - _function_name_: A **string** representing the name of the the function that is being invoked.
-
-  - _event_type_: A **string** with the type of event that triggered the function invocation.
-
   - _devrev_endpoint_: A **string** representing the DevRev endpoint URL
 
 - _input_data_


### PR DESCRIPTION
This update to the documentation has been wrong - AirdropEvent doesn't have function_name and event_type in execution_metadata - thus removing it.

These two attributes get passed to the runner so it would be very beneficial for the rendering robustness, if we would document it in the proper way.

work-item: https://app.devrev.ai/devrev/works/ISS-190744