### PR TITLE
Minor updates for more robust generation

### DIFF
--- a/devrev-snapin-template.plain
+++ b/devrev-snapin-template.plain
@@ -27,7 +27,7 @@
 
 - The Snap-In will run on Node.js as the runtime environment.
 
-- The Snap-In should use The Airdrop SDK Library version "1.5.1" for handling data extraction and loading, pushing data, event-driven actions, state management, and artifact handling.
+- The Snap-In should use The Airdrop SDK Library version "1.8.0" for handling data extraction and loading, pushing data, event-driven actions, state management, and artifact handling.
 
 - Use snake_case for JSON keys.
 

--- a/docs/airdrop_sdk_library_documentation.md
+++ b/docs/airdrop_sdk_library_documentation.md
@@ -444,7 +444,7 @@ spawn({ event, initialState, workerPath, options, initialDomainMapping });
 
 - _initialDomainMapping_
 
-  Optional. An **object** containing the initial domain mapping.
+  Required. An **object** containing the initial domain mapping.
 
 - _options_
 

--- a/docs/attachments-extraction.md
+++ b/docs/attachments-extraction.md
@@ -83,7 +83,6 @@ processTask({
     }
   },
   onTimeout: async ({ adapter }) => {
-    await adapter.postState();
     await adapter.emit(ExtractorEventType.ExtractionAttachmentsProgress, {
       progress: 50,
     });

--- a/templates/spawn_method_instructions.plain
+++ b/templates/spawn_method_instructions.plain
@@ -2,7 +2,7 @@
   - The Extraction Function should start The Worker Thread with timeout of 10 minutes.
   - "isLocalDevelopment" *must not* be set.
   - "initialState" should be The Extraction State Object with all "completed" fields set to false, and all the rest of the fields in The Extraction State Object set to undefined, false, 0, or empty string, depending on the type of the field.
-  - Use The Initial Domain Mapping JSON object for initialDomainMapping parameter when spawning a new worker.
-  - Note: The Initial Domain Mapping JSON object should be read directly from the JSON file.
   - Note: No additional fields should be added to The Extraction State Object.
   - Note: The Worker Thread must be implemented in TypeScript and it should be referenced with a .ts extension, not .js.
+- Use The Initial Domain Mapping JSON object for initialDomainMapping parameter when spawning a new worker.
+  - Note: The Initial Domain Mapping JSON object should be read directly from the JSON file.


### PR DESCRIPTION
This pull request updates documentation and instructions related to the Snap-In and Airdrop SDK usage, with a focus on clarifying requirements for the SDK version, the `initialDomainMapping` parameter, and the handling of extraction state. The most important changes are summarized below:

**SDK Version and Usage Requirements:**
* Updated the required Airdrop SDK Library version from "1.5.1" to "1.8.0" in the Snap-In template documentation, ensuring that all features and fixes up to the latest version are utilized.

**initialDomainMapping Parameter Clarifications:**
* Changed the `initialDomainMapping` parameter from optional to required in the documentation for the `spawn` method, making it clear that this object must always be provided.
* Clarified in the spawn method instructions that the initial domain mapping JSON object must be used for the `initialDomainMapping` parameter, and that it should be read directly from the JSON file.

**Extraction Task Handling:**
* Removed the call to `adapter.postState()` in the `onTimeout` handler within the attachments extraction process documentation, likely to streamline or correct the timeout flow.

Issue: https://app.devrev.ai/devrev/works/ISS-206307